### PR TITLE
Implement simple manifest of published files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,25 @@ Finally, run your Nextflow pipeline. You do not need to modify your pipeline scr
 
 ## Development
 
-Refer to the [nf-hello](https://github.com/nextflow-io/nf-hello) README for instructions on how to build, test, and publish Nextflow plugins.
+Run the following commands to build and test the nf-prov Nextflow plugin. Refer to the [nf-hello](https://github.com/nextflow-io/nf-hello) README for additional instructions (_e.g._ for publishing the plugin).
+
+```console
+# (Optional) Checkout relevant feature branch
+# git checkout <branch>
+
+# Create an empty folder for nf-prov and nextflow repos
+git clone --depth 1 https://github.com/nextflow-io/nextflow ../nextflow-nf-prov
+
+# Prepare the nextflow repo
+cd ../nextflow-nf-prov && ./gradlew compile exportClasspath && cd -
+
+# Prepare the nf-prov repo
+grep -v 'includeBuild' settings.gradle > settings.gradle.bkp
+echo "includeBuild('../nextflow-nf-prov')" >> settings.gradle.bkp
+mv -f settings.gradle.bkp settings.gradle
+./gradlew compileGroovy
+./gradlew assemble
+
+# Launch
+./launch.sh run test.nf -plugins nf-prov
+```

--- a/test.nf
+++ b/test.nf
@@ -1,0 +1,22 @@
+nextflow.enable.dsl=2
+
+process RNG {
+
+    publishDir "outputs/", mode: 'copy'
+
+    input:
+    val prefix
+
+    output:
+    path "${prefix}.txt"
+
+    script:
+    """
+    echo \$RANDOM > ${prefix}.txt
+    """
+
+}
+
+workflow {
+    channel.from('r1', 'r2', 'r3') | RNG
+}


### PR DESCRIPTION
In this initial proof of concept, I've adapted the [nf-quilt](https://github.com/nextflow-io/nf-quilt) plugin to generate a simple list of published files. For context, the long-term goal of this plugin is to generate a rich manifest JSON file that includes provenance information about the published files (_e.g._ process name, tag name, `meta` contents). 

To test this PR, follow the instructions in [this README](https://github.com/Sage-Bionetworks-Workflows/nf-prov/tree/bgrande/poc#development). Here's an example test run:

```console
$ ./launch.sh run test.nf -plugins nf-prov
N E X T F L O W  ~  version 22.10.0-RC3
Launching `test.nf` [furious_bohr] DSL2 - revision: 90eefed344
executor >  local (3)
[3a/3c8df0] process > RNG (2) [100%] 3 of 3 ✔

$ cat manifest.txt 
/Users/bgrande/Repos/nf-prov-project/nf-prov/outputs/r1.txt
/Users/bgrande/Repos/nf-prov-project/nf-prov/outputs/r3.txt
/Users/bgrande/Repos/nf-prov-project/nf-prov/outputs/r2.txt
```

## `nf-core/taxprofiler` test

I was able to test the `dev` branch of `nf-core/taxprofiler` with a barebones profile (`test_nothing`), and the simple manifest file was generated as expected. 

```console
$ ./gradlew assemble && ./launch.sh run nf-core/taxprofiler -r dev -plugins nf-prov -profile docker,test_nothing --outdir out/
BUILD SUCCESSFUL in 1s
25 actionable tasks: 25 up-to-date
N E X T F L O W  ~  version 22.10.0
[...]
-[nf-core/taxprofiler] Pipeline completed successfully-

$ cat manifest.txt
/home/ec2-user/nf-prov-project/nf-prov/out/pipeline_info/database_sheet.valid.csv
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/ERR3201952_ERR3201952_raw_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_B_raw_2_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_B_raw_1_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2613_ERR5766181_raw_2_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2613_ERR5766181_raw_1_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_raw_1_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_raw_2_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766180_raw_fastqc.html
/home/ec2-user/nf-prov-project/nf-prov/out/pipeline_info/software_versions.yml
/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_report.html
/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_data
/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_plots
```

## ~Problem~

**Edit:** This problem has been solved by running `./gradlew assemble`. Shout out to Paolo for this fix! 

<details>
I've been testing with the Nextflow pipeline included below, but I'm not getting the expected manifest file. I've tried adding log statements to see if the plugin code is running at all, but I'm not seeing these appear in the `.nextflow.log` file. I do see statements in the log file indicating that the plugin is being started though. I've included the command that I'm using to compile and test the plugin as well as the relevant output from the log file. 

```console
$ ./gradlew compileGroovy && ./launch.sh run main.nf -plugins nf-prov
BUILD SUCCESSFUL in 770ms
21 actionable tasks: 21 up-to-date
N E X T F L O W  ~  version 22.10.0-RC3
Launching `main.nf` [disturbed_lavoisier] DSL2 - revision: 90eefed344
executor >  local (3)
[ce/9b2d73] process > RNG (3) [100%] 3 of 3 ✔


❯ grep -c 'Plugin initialized' .nextflow.log 
0

$ grep 'nf-prov' .nextflow.log | grep -v 'nf-prov-project'
Oct-10 17:40:14.794 [main] DEBUG nextflow.cli.Launcher - $> ../nextflow/launch.sh run main.nf -plugins nf-prov
Oct-10 17:40:14.927 [main] INFO  org.pf4j.AbstractPluginManager - Plugin 'nf-prov@0.1.0' resolved
Oct-10 17:40:14.998 [main] DEBUG nextflow.plugin.PluginsFacade - Plugins declared=[nf-prov]
Oct-10 17:40:14.998 [main] DEBUG nextflow.plugin.PluginsFacade - Plugins resolved requirement=[nf-prov]
Oct-10 17:40:14.999 [main] DEBUG nextflow.plugin.PluginUpdater - Starting plugin nf-prov version: 0.1.0
Oct-10 17:40:14.999 [main] INFO  org.pf4j.AbstractPluginManager - Start plugin 'nf-prov@0.1.0'
Oct-10 17:40:15.004 [main] DEBUG nextflow.plugin.BasePlugin - Plugin started nf-prov@0.1.0
Oct-10 17:40:16.364 [main] INFO  org.pf4j.AbstractPluginManager - Stop plugin 'nf-prov@0.1.0'
Oct-10 17:40:16.364 [main] DEBUG nextflow.plugin.BasePlugin - Plugin stopped nf-prov
```

</details>

## ~Test Pipeline~

**Edit:** This pipeline was moved to `test.nf` in the repository root. 