### PR TITLE
Output JSON and add `enabled`/`overwrite` configuration options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           architecture: x64
 
       - name: Setup Nextflow
-        run: >
+        run: |
           git clone --depth 1 https://github.com/nextflow-io/nextflow ../nextflow
           cd ../nextflow && ./gradlew compile exportClasspath && cd -
           echo "includeBuild('../nextflow')" >> settings.gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,12 @@ jobs:
           java-version: ${{matrix.java_version}}
           architecture: x64
 
+      - name: Setup Nextflow
+        run: >
+          git clone --depth 1 https://github.com/nextflow-io/nextflow ../nextflow
+          cd ../nextflow && ./gradlew compile exportClasspath && cd -
+          echo "includeBuild('../nextflow')" >> settings.gradle
+      
       - name: Compile
         run: ./gradlew assemble
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ cd ../nextflow-nf-prov && ./gradlew compile exportClasspath && cd -
 grep -v 'includeBuild' settings.gradle > settings.gradle.bkp
 echo "includeBuild('../nextflow-nf-prov')" >> settings.gradle.bkp
 mv -f settings.gradle.bkp settings.gradle
-./gradlew compileGroovy
 ./gradlew assemble
 
 # Launch

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,4 @@
+prov {
+	overwrite = true
+	file = 'out/manifest.json'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,5 @@
 prov {
-	overwrite = true
-	file = 'out/manifest.json'
+    enabled = true
+    overwrite = true
+    file = 'out/manifest.json'
 }

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -45,6 +45,8 @@ class ProvObserver implements TraceObserver {
 
     private Map config
 
+    private boolean enabled
+
     private Path path
 
     private List<PathMatcher> matchers
@@ -55,6 +57,7 @@ class ProvObserver implements TraceObserver {
     void onFlowCreate(Session session) {
         this.session = session
         this.config = session.config
+        this.enabled = this.config.navigate('prov.enabled', true)
         this.config.overwrite = this.config.navigate('prov.overwrite', false)
         this.config.patterns = this.config.navigate('prov.patterns', [])
         this.config.file = this.config.navigate('prov.file', DEF_FILE_NAME)
@@ -62,7 +65,7 @@ class ProvObserver implements TraceObserver {
 
         // check file existance
         final attrs = FileHelper.readAttributes(this.path)
-        if( attrs ) {
+        if( this.enabled && attrs ) {
             if( this.config.overwrite && (attrs.isDirectory() || !this.path.delete()) )
                 throw new AbortOperationException("Unable to overwrite existing file manifest: ${this.path.toUriString()}")
             else if( !this.config.overwrite )
@@ -94,7 +97,7 @@ class ProvObserver implements TraceObserver {
     @Override
     void onFlowComplete() {
         // make sure there are files to publish
-        if ( this.publishedPaths.isEmpty() ) {
+        if ( !this.enabled || this.publishedPaths.isEmpty() ) {
             return
         }
 

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -26,7 +26,6 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.trace.TraceObserver
-import nextflow.trace.TraceHelper
 import nextflow.file.FileHelper
 import nextflow.exception.AbortOperationException
 

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -80,7 +80,7 @@ class ProvObserver implements TraceObserver {
     }
 
     @Override
-    void onFilePublish(Path source, Path destination) {
+    void onFilePublish(Path destination, Path source) {
         boolean match = this.matchers.isEmpty() || this.matchers.any { matcher ->
             matcher.matches(destination)
         }

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -80,13 +80,14 @@ class ProvObserver implements TraceObserver {
     }
 
     @Override
-    void onFilePublish(Path destination) {
+    void onFilePublish(Path source, Path destination) {
         boolean match = this.matchers.isEmpty() || this.matchers.any { matcher ->
             matcher.matches(destination)
         }
 
         def pathMap = [
-            'uri': destination.toUriString()
+            'source': source.toUriString(),
+            'target': destination.toUriString()
         ]
 
         if ( match ) {
@@ -102,9 +103,9 @@ class ProvObserver implements TraceObserver {
         }
 
         // generate manifest map
-        def manifest = [ "outputs": [] ]
+        def manifest = [ "published": [] ]
         this.publishedPaths.each { path ->
-            manifest.outputs.add(path)
+            manifest.published.add(path)
         }
 
         // output manifest map as JSON

--- a/test.nf
+++ b/test.nf
@@ -2,7 +2,7 @@ nextflow.enable.dsl=2
 
 process RNG {
 
-    publishDir "outputs/", mode: 'copy'
+    publishDir "out/", mode: 'copy'
 
     input:
     val prefix


### PR DESCRIPTION
This PR changes the output format from a simple list of published files to a JSON file manifest. I also added the `enabled` and `overwrite` configuration options in line with other features like [`trace`](https://nextflow.io/docs/latest/config.html#scope-trace). 

Depends on nextflow-io/nextflow/pull/3284

## Simple test

```console
❯ ./gradlew assemble && ./launch.sh run test.nf -plugins nf-prov && cat out/manifest.json

BUILD SUCCESSFUL in 3s
25 actionable tasks: 4 executed, 21 up-to-date

N E X T F L O W  ~  version 22.10.0-RC3
Launching `test.nf` [amazing_archimedes] DSL2 - revision: a235c05921
executor >  local (3)
[66/186307] process > RNG (3) [100%] 3 of 3 ✔

{
    "published": [
        {
            "source": "/Users/bgrande/Repos/nf-prov-project/nf-prov/work/4f/88b1ba088389561c84273acdbb3743/r1.txt",
            "target": "/Users/bgrande/Repos/nf-prov-project/nf-prov/out/r1.txt"
        },
        {
            "source": "/Users/bgrande/Repos/nf-prov-project/nf-prov/work/7f/70b6933d6fe89a52e1702a1eb7db83/r2.txt",
            "target": "/Users/bgrande/Repos/nf-prov-project/nf-prov/out/r2.txt"
        },
        {
            "source": "/Users/bgrande/Repos/nf-prov-project/nf-prov/work/66/186307dcf6be2de0c0ef70d967e37a/r3.txt",
            "target": "/Users/bgrande/Repos/nf-prov-project/nf-prov/out/r3.txt"
        }
    ]
}
```

## nf-core/taxprofiler test

```console
$ ./gradlew assemble && ./launch.sh run nf-core/taxprofiler -r dev -plugins nf-prov -profile docker,test_nothing --outdir out/

BUILD SUCCESSFUL in 990ms
25 actionable tasks: 1 executed, 24 up-to-date
N E X T F L O W  ~  version 22.11.0-SNAPSHOT
[...]
-[nf-core/taxprofiler] Pipeline completed successfully-

$ cat out/manifest.json
{
    "published": [
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/7f/cd5d21683dacf5a63765c6f7100ebf/database_sheet.valid.csv",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/pipeline_info/database_sheet.valid.csv"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/51/dbe87d0250eeb96d4692c99a00ad38/ERR3201952_ERR3201952_raw_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/ERR3201952_ERR3201952_raw_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/02/97aec727258551c0fe63a01692bce3/2613_ERR5766181_raw_1_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2613_ERR5766181_raw_1_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/02/97aec727258551c0fe63a01692bce3/2613_ERR5766181_raw_2_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2613_ERR5766181_raw_2_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/4f/5e1565d0c1f3846991fab28ab83c78/software_versions.yml",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/pipeline_info/software_versions.yml"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/b9/f6f8ff35b9d8d1c7748d86842d2d79/2612_ERR5766176_B_raw_1_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_B_raw_1_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/b9/f6f8ff35b9d8d1c7748d86842d2d79/2612_ERR5766176_B_raw_2_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_B_raw_2_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/41/8f1dcdc3591700605f944db714a230/2612_ERR5766180_raw_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766180_raw_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/36/52232ccf71109338219de2cd442bc3/2612_ERR5766176_raw_2_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_raw_2_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/36/52232ccf71109338219de2cd442bc3/2612_ERR5766176_raw_1_fastqc.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/fastqc/raw/2612_ERR5766176_raw_1_fastqc.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/46/88c63d875d374e7961e5d72a870e94/multiqc_report.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_report.html"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/46/88c63d875d374e7961e5d72a870e94/multiqc_data",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_data"
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/46/88c63d875d374e7961e5d72a870e94/multiqc_plots",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_plots"
        }
    ]
}
```