### PR TITLE
Add `tasks` and `pipeline` to output manifest

### DIFF
--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -90,7 +90,9 @@ class ProvObserver implements TraceObserver {
         def taskConfig = taskRun.config
 
         def taskMap = [
-            'id': taskRun.id
+            'id': taskRun.id as int,
+            'inputs': taskRun.inputs.collect {it.value as String}.flatten(),
+            'outputs': taskRun.outputs.collect {it.value as String}.flatten()
         ]
 
         this.tasks.add(taskMap)
@@ -117,6 +119,19 @@ class ProvObserver implements TraceObserver {
         // make sure there are files to publish
         if ( !this.enabled || this.published.isEmpty() ) {
             return
+        }
+
+        // generate temporary output-task map
+        def outputTaskMap = [:]
+        this.tasks.each { task ->
+            task.outputs.each { output ->
+                outputTaskMap.put(output, task)
+            }
+        }
+
+        // add task information to published files
+        this.published.each { path ->
+            path['publishingTask'] = outputTaskMap[path.source]
         }
 
         // generate manifest map

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -90,8 +90,8 @@ class ProvObserver implements TraceObserver {
 
         def taskMap = [
             'id': taskRun.id as int,
-            'inputs': taskRun.inputs.size(),
-            'outputs': taskRun.outputs.size()
+            'inputs': taskRun.inputs.collect {it.value as String}.flatten(),
+            'outputs': taskRun.outputs.collect {it.value as String}.flatten()
         ]
 
         this.tasks.add(taskMap)

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -90,8 +90,8 @@ class ProvObserver implements TraceObserver {
 
         def taskMap = [
             'id': taskRun.id as int,
-            'inputs': taskRun.inputs.collect {it.value as String}.flatten(),
-            'outputs': taskRun.outputs.collect {it.value as String}.flatten()
+            'inputs': taskRun.inputs.size(),
+            'outputs': taskRun.outputs.size()
         ]
 
         this.tasks.add(taskMap)
@@ -135,7 +135,7 @@ class ProvObserver implements TraceObserver {
 
         // generate manifest map
         def manifest = [
-            'config': this.config,
+            'pipeline': this.config.manifest,
             'published': this.published,
             'tasks': this.tasks
         ]


### PR DESCRIPTION
In this PR, I add additional information to the file manifest. The `pipeline` value will include the pipeline manifest (_e.g._ workflow name and version). The `tasks` value is very basic for now, but I plan on exploring the `TaskHandler` (and the included `TaskRun`) and `TraceRecord` instances to expand `tasks`. 

I have also associated each published file with the task that performs the publishing. This needs to be refined a bit, as you can see with the `nf-core/taxprofiler` test, but the foundation is there. I'll need to figure out how to handle these `FileHolder` objects. 

## Simple test

<details>

```console
$ ./gradlew assemble && ./launch.sh run test.nf -plugins nf-prov

BUILD SUCCESSFUL in 1s
25 actionable tasks: 25 up-to-date
N E X T F L O W  ~  version 22.11.0-SNAPSHOT
Launching `test.nf` [astonishing_bartik] DSL2 - revision: a235c05921
executor >  local (3)
[67/3f37ef] process > RNG (3) [100%] 3 of 3 ✔

$ cat out/manifest.json 
{
    "pipeline": null,
    "published": [
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/4d/391a13e7c70c44119603bffe91f50d/r2.txt",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/r2.txt",
            "publishingTask": {
                "id": 2,
                "name": "RNG (2)",
                "cached": false,
                "process": "RNG",
                "inputs": [
                    "r2",
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/4d/391a13e7c70c44119603bffe91f50d/r2.txt"
                ]
            }
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/1a/93f5a172b26ad417e25c0b43f268fe/r1.txt",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/r1.txt",
            "publishingTask": {
                "id": 1,
                "name": "RNG (1)",
                "cached": false,
                "process": "RNG",
                "inputs": [
                    "r1",
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/1a/93f5a172b26ad417e25c0b43f268fe/r1.txt"
                ]
            }
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/67/3f37ef4f5b50a91dad873f66c2a97e/r3.txt",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/r3.txt",
            "publishingTask": {
                "id": 3,
                "name": "RNG (3)",
                "cached": false,
                "process": "RNG",
                "inputs": [
                    "r3",
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/67/3f37ef4f5b50a91dad873f66c2a97e/r3.txt"
                ]
            }
        }
    ],
    "tasks": [
        {
            "id": 2,
            "name": "RNG (2)",
            "cached": false,
            "process": "RNG",
            "inputs": [
                "r2",
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/4d/391a13e7c70c44119603bffe91f50d/r2.txt"
            ]
        },
        {
            "id": 1,
            "name": "RNG (1)",
            "cached": false,
            "process": "RNG",
            "inputs": [
                "r1",
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/1a/93f5a172b26ad417e25c0b43f268fe/r1.txt"
            ]
        },
        {
            "id": 3,
            "name": "RNG (3)",
            "cached": false,
            "process": "RNG",
            "inputs": [
                "r3",
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/67/3f37ef4f5b50a91dad873f66c2a97e/r3.txt"
            ]
        }
    ]
}
```

</details>

## nf-core/taxprofiler test

<details>

```console
$ ./gradlew assemble && ./launch.sh run nf-core/taxprofiler -r dev -plugins nf-prov -profile docker,test_nothing --outdir out/ -resume 

BUILD SUCCESSFUL in 4s
25 actionable tasks: 4 executed, 21 up-to-date
N E X T F L O W  ~  version 22.11.0-SNAPSHOT
[...]
-[nf-core/taxprofiler] Pipeline completed successfully-

$ cat out/manifest.json 
{
    "pipeline": {
        "name": "nf-core/taxprofiler",
        "author": "nf-core community",
        "homePage": "https://github.com/nf-core/taxprofiler",
        "description": "Taxonomic profiling of shotgun metagenomic data",
        "mainScript": "main.nf",
        "nextflowVersion": "!>=21.10.3",
        "version": "1.0dev",
        "doi": ""
    },
    "published": [
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions.yml",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/pipeline_info/software_versions.yml",
            "publishingTask": {
                "id": 8,
                "name": "NFCORE_TAXPROFILER:TAXPROFILER:CUSTOM_DUMPSOFTWAREVERSIONS (1)",
                "cached": false,
                "process": "NFCORE_TAXPROFILER:TAXPROFILER:CUSTOM_DUMPSOFTWAREVERSIONS",
                "inputs": [
                    [
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/1d/b8cd7a8b5fe19a0475d86c6b1274a4/collated_versions.yml"
                    ],
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions.yml",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions_mqc.yml",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/versions.yml"
                ]
            }
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_report.html",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_report.html",
            "publishingTask": {
                "id": 17,
                "name": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
                "cached": false,
                "process": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
                "inputs": [
                    [
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/3a/5f09fd0848cf1560cb050cd12409e1/workflow_summary_mqc.yaml",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/c7/a76f9e9f3dc6573e305c1b498d026e/methods_description_mqc.yaml",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/ERR3201952_ERR3201952_raw_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/2612_ERR5766180_raw_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions_mqc.yml"
                    ],
                    [
                        "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/assets/multiqc_config.yml"
                    ],
                    [
                        
                    ],
                    [
                        "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/docs/images/nf-core-taxprofiler_logo_custom_light.png"
                    ],
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_report.html",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_data",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_plots",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/versions.yml"
                ]
            }
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_data",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_data",
            "publishingTask": {
                "id": 17,
                "name": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
                "cached": false,
                "process": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
                "inputs": [
                    [
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/3a/5f09fd0848cf1560cb050cd12409e1/workflow_summary_mqc.yaml",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/c7/a76f9e9f3dc6573e305c1b498d026e/methods_description_mqc.yaml",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/ERR3201952_ERR3201952_raw_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/2612_ERR5766180_raw_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions_mqc.yml"
                    ],
                    [
                        "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/assets/multiqc_config.yml"
                    ],
                    [
                        
                    ],
                    [
                        "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/docs/images/nf-core-taxprofiler_logo_custom_light.png"
                    ],
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_report.html",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_data",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_plots",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/versions.yml"
                ]
            }
        },
        {
            "source": "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_plots",
            "target": "/home/ec2-user/nf-prov-project/nf-prov/out/multiqc/multiqc_plots",
            "publishingTask": {
                "id": 17,
                "name": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
                "cached": false,
                "process": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
                "inputs": [
                    [
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/3a/5f09fd0848cf1560cb050cd12409e1/workflow_summary_mqc.yaml",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/c7/a76f9e9f3dc6573e305c1b498d026e/methods_description_mqc.yaml",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/ERR3201952_ERR3201952_raw_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_1_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_2_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/2612_ERR5766180_raw_fastqc.zip",
                        "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions_mqc.yml"
                    ],
                    [
                        "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/assets/multiqc_config.yml"
                    ],
                    [
                        
                    ],
                    [
                        "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/docs/images/nf-core-taxprofiler_logo_custom_light.png"
                    ],
                    true
                ],
                "outputs": [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_report.html",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_data",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_plots",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/versions.yml"
                ]
            }
        }
    ],
    "tasks": [
        {
            "id": 3,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:INPUT_CHECK:EIDO_VALIDATE (samplesheet.csv)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:INPUT_CHECK:EIDO_VALIDATE",
            "inputs": [
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/48/a554635a0912b54e0984423dd3a35e/samplesheet.csv"
                ],
                [
                    "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/assets/samplesheet_schema.yaml"
                ],
                [
                    
                ],
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/9c/bf020df02c96f20e4bc050d9341ed7/versions.yml",
                "/home/ec2-user/nf-prov-project/nf-prov/work/9c/bf020df02c96f20e4bc050d9341ed7/validation.log"
            ]
        },
        {
            "id": 1,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:DATABASE_CHECK (database.csv)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:DATABASE_CHECK",
            "inputs": [
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/84/2aac0ec83abc3bcc73e358868e9684/database.csv"
                ],
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/25/e5a8cbede66251e88befd1a6b66a1e/database_sheet.valid.csv",
                "/home/ec2-user/nf-prov-project/nf-prov/work/25/e5a8cbede66251e88befd1a6b66a1e/versions.yml"
            ]
        },
        {
            "id": 2,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:INPUT_CHECK:EIDO_CONVERT (samplesheet.csv)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:INPUT_CHECK:EIDO_CONVERT",
            "inputs": [
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/48/a554635a0912b54e0984423dd3a35e/samplesheet.csv"
                ],
                "csv",
                [
                    
                ],
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/27/d2b6c8e70c86acda530648c1a22e8e/versions.yml",
                "/home/ec2-user/nf-prov-project/nf-prov/work/27/d2b6c8e70c86acda530648c1a22e8e/samplesheet_converted.csv"
            ]
        },
        {
            "id": 4,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC (ERR3201952)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC",
            "inputs": [
                {
                    "id": "ERR3201952",
                    "run_accession": "ERR3201952",
                    "instrument_platform": "OXFORD_NANOPORE",
                    "single_end": true,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/07/345f2dc00c373e85e7fe384422e230/ERR3201952.fastq.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "id": "ERR3201952",
                    "run_accession": "ERR3201952",
                    "instrument_platform": "OXFORD_NANOPORE",
                    "single_end": true,
                    "is_fasta": false
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/ERR3201952_ERR3201952_raw_fastqc.html",
                {
                    "id": "ERR3201952",
                    "run_accession": "ERR3201952",
                    "instrument_platform": "OXFORD_NANOPORE",
                    "single_end": true,
                    "is_fasta": false
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/ERR3201952_ERR3201952_raw_fastqc.zip",
                "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/versions.yml"
            ]
        },
        {
            "id": 5,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC (2613)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC",
            "inputs": [
                {
                    "id": "2613",
                    "run_accession": "ERR5766181",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/df/d56c5d44f280b1a6bdb39dd5342773/ERX5474937_ERR5766181_1.fastq.gz",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/e5/231fa209e23719cdf7d8a628a99786/ERX5474937_ERR5766181_2.fastq.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "id": "2613",
                    "run_accession": "ERR5766181",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_1_fastqc.html",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_2_fastqc.html"
                ],
                {
                    "id": "2613",
                    "run_accession": "ERR5766181",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_1_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_2_fastqc.zip"
                ],
                "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/versions.yml"
            ]
        },
        {
            "id": 6,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (testdb-malt.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "malt",
                    "db_name": "malt85",
                    "db_params": "-id 85"
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/2c/ad92cb92edcd109292cb32f156ae38/testdb-malt.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "malt",
                    "db_name": "malt85",
                    "db_params": "-id 85"
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/fd/83da0becd74bea6c2902d5bc345832/testdb-malt",
                "/home/ec2-user/nf-prov-project/nf-prov/work/fd/83da0becd74bea6c2902d5bc345832/versions.yml"
            ]
        },
        {
            "id": 7,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (testdb-malt.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "malt",
                    "db_name": "malt95",
                    "db_params": "-id 90"
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/2c/ad92cb92edcd109292cb32f156ae38/testdb-malt.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "malt",
                    "db_name": "malt95",
                    "db_params": "-id 90"
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/2e/34a580a592f8ff479d28ecf700ef4a/testdb-malt",
                "/home/ec2-user/nf-prov-project/nf-prov/work/2e/34a580a592f8ff479d28ecf700ef4a/versions.yml"
            ]
        },
        {
            "id": 9,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (testdb-bracken.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "bracken",
                    "db_name": "db1",
                    "db_params": ""
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/af/df60ec1ba54459d30a94af3e53f322/testdb-bracken.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "bracken",
                    "db_name": "db1",
                    "db_params": ""
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/65/f05190aecce79553fd8996b8faf2f8/testdb-bracken",
                "/home/ec2-user/nf-prov-project/nf-prov/work/65/f05190aecce79553fd8996b8faf2f8/versions.yml"
            ]
        },
        {
            "id": 10,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (testdb-kraken2.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "kraken2",
                    "db_name": "db2",
                    "db_params": "--quick"
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/ca/4790b4361a88a713875d670e103a5a/testdb-kraken2.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "kraken2",
                    "db_name": "db2",
                    "db_params": "--quick"
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/ed/7a807ab34e0378e60f107224d850ee/testdb-kraken2",
                "/home/ec2-user/nf-prov-project/nf-prov/work/ed/7a807ab34e0378e60f107224d850ee/versions.yml"
            ]
        },
        {
            "id": 11,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC (2612)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC",
            "inputs": [
                {
                    "id": "2612",
                    "run_accession": "ERR5766176",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/d1/a59c06f17a9140a0a1042fd380c060/ERX5474932_ERR5766176_1.fastq.gz",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/fd/32daf5bc7962dd877ceb932779511c/ERX5474932_ERR5766176_2.fastq.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "id": "2612",
                    "run_accession": "ERR5766176",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_1_fastqc.html",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_2_fastqc.html"
                ],
                {
                    "id": "2612",
                    "run_accession": "ERR5766176",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_1_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_2_fastqc.zip"
                ],
                "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/versions.yml"
            ]
        },
        {
            "id": 13,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (metaphlan_database.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "metaphlan3",
                    "db_name": "db4",
                    "db_params": ""
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/bd/ebbd1a6b333424bb2dc517e7d52950/metaphlan_database.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "metaphlan3",
                    "db_name": "db4",
                    "db_params": ""
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/9e/39ef68bf5c330436348cab8489c24a/metaphlan_database",
                "/home/ec2-user/nf-prov-project/nf-prov/work/9e/39ef68bf5c330436348cab8489c24a/versions.yml"
            ]
        },
        {
            "id": 14,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC (2612)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC",
            "inputs": [
                {
                    "id": "2612",
                    "run_accession": "ERR5766176_B",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/89/9b3e2047cb5e215593af611ce4aff5/ERX5474932_ERR5766176_B_1.fastq.gz",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/cf/108f35f2747d9dab3dc120d4cff413/ERX5474932_ERR5766176_B_2.fastq.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "id": "2612",
                    "run_accession": "ERR5766176_B",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_1_fastqc.html",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_2_fastqc.html"
                ],
                {
                    "id": "2612",
                    "run_accession": "ERR5766176_B",
                    "instrument_platform": "ILLUMINA",
                    "single_end": false,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_1_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_2_fastqc.zip"
                ],
                "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/versions.yml"
            ]
        },
        {
            "id": 12,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (test-db-centrifuge.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "centrifuge",
                    "db_name": "db3",
                    "db_params": ""
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/6a/ffb959009dfd052d9c95401b875919/test-db-centrifuge.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "centrifuge",
                    "db_name": "db3",
                    "db_params": ""
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/15/86e4b4156426b331b3a6f7f616b4ee/test-db-centrifuge",
                "/home/ec2-user/nf-prov-project/nf-prov/work/15/86e4b4156426b331b3a6f7f616b4ee/versions.yml"
            ]
        },
        {
            "id": 15,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC (2612)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:FASTQC",
            "inputs": [
                {
                    "id": "2612",
                    "run_accession": "ERR5766180",
                    "instrument_platform": "ILLUMINA",
                    "single_end": true,
                    "is_fasta": false
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/2e/b3147dafca9a6ef3ec3346dc4a7a1d/ERX5474936_ERR5766180_1.fastq.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "id": "2612",
                    "run_accession": "ERR5766180",
                    "instrument_platform": "ILLUMINA",
                    "single_end": true,
                    "is_fasta": false
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/2612_ERR5766180_raw_fastqc.html",
                {
                    "id": "2612",
                    "run_accession": "ERR5766180",
                    "instrument_platform": "ILLUMINA",
                    "single_end": true,
                    "is_fasta": false
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/2612_ERR5766180_raw_fastqc.zip",
                "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/versions.yml"
            ]
        },
        {
            "id": 16,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR (kaiju.tar.gz)",
            "cached": true,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:DB_CHECK:UNTAR",
            "inputs": [
                {
                    "tool": "kaiju",
                    "db_name": "db5",
                    "db_params": ""
                },
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/stage/48/8f10d09f6d1bb320fb3ffbb4a6a0b0/kaiju.tar.gz"
                ],
                true
            ],
            "outputs": [
                {
                    "tool": "kaiju",
                    "db_name": "db5",
                    "db_params": ""
                },
                "/home/ec2-user/nf-prov-project/nf-prov/work/30/b4cc423c7dfde44dcefcecf877723f/kaiju",
                "/home/ec2-user/nf-prov-project/nf-prov/work/30/b4cc423c7dfde44dcefcecf877723f/versions.yml"
            ]
        },
        {
            "id": 8,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:CUSTOM_DUMPSOFTWAREVERSIONS (1)",
            "cached": false,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:CUSTOM_DUMPSOFTWAREVERSIONS",
            "inputs": [
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/1d/b8cd7a8b5fe19a0475d86c6b1274a4/collated_versions.yml"
                ],
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions.yml",
                "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions_mqc.yml",
                "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/versions.yml"
            ]
        },
        {
            "id": 17,
            "name": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
            "cached": false,
            "process": "NFCORE_TAXPROFILER:TAXPROFILER:MULTIQC",
            "inputs": [
                [
                    "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/3a/5f09fd0848cf1560cb050cd12409e1/workflow_summary_mqc.yaml",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/tmp/c7/a76f9e9f3dc6573e305c1b498d026e/methods_description_mqc.yaml",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/59/19c41db4a37b35412651dfd8214645/ERR3201952_ERR3201952_raw_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_1_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e9/81be978552f3ca26a5020c2a1a7dce/2613_ERR5766181_raw_2_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_1_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/6a/9a6dd185cb5dc16cc58de4f0480fdc/2612_ERR5766176_raw_2_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_1_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/e4/9ad1468017b4a02234fb9717539043/2612_ERR5766176_B_raw_2_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/40/b1f4d87eaeab15ddf2d6865d955f0a/2612_ERR5766180_raw_fastqc.zip",
                    "/home/ec2-user/nf-prov-project/nf-prov/work/5b/05e9afd22aa79afc6699ee18b29ffc/software_versions_mqc.yml"
                ],
                [
                    "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/assets/multiqc_config.yml"
                ],
                [
                    
                ],
                [
                    "/home/ec2-user/.nextflow/assets/nf-core/taxprofiler/docs/images/nf-core-taxprofiler_logo_custom_light.png"
                ],
                true
            ],
            "outputs": [
                "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_report.html",
                "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_data",
                "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/multiqc_plots",
                "/home/ec2-user/nf-prov-project/nf-prov/work/23/c616c584e11161feb316099f5a8f3c/versions.yml"
            ]
        }
    ]
}
```

</details>